### PR TITLE
Fixes to vertvisc CS handling, some memory transfer fixes

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1659,10 +1659,8 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   !$omp target enter data map(alloc: CS%hor_visc)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc, ADp=CS%ADp)
 
-#ifdef __NVCOMPILER_LLVM__
   allocate(CS%vertvisc_CSp)
-#endif
-  !$omp target enter data map(to: CS%vertvisc_CSp)
+  !$omp target enter data map(alloc: CS%vertvisc_CSp)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
                      ntrunc, CS%vertvisc_CSp, CS%fpmix)
   CS%set_visc_CSp => set_visc

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -637,7 +637,9 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   !$omp target update to(up, vp, h, dz)
   call vertvisc_coef(up, vp, h, dz, forces, visc, tv, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC, VarMix)
 
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
   call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
+  !$omp target update from(CS%visc_rem_u, CS%visc_rem_v)
 
   call cpu_clock_end(id_clock_vertvisc)
   if (showCallTree) call callTree_wayPoint("done with vertvisc_coef (step_MOM_dyn_split_RK2)")
@@ -781,7 +783,6 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   call vertvisc_coef(up, vp, h, dz, forces, visc, tv, dt_pred, G, GV, US, CS%vertvisc_CSp, &
                      CS%OBC, VarMix)
 
-
   if (CS%fpmix) then
     hbl(:,:) = 0.0
     if (ASSOCIATED(CS%KPP_CSp)) call KPP_get_BLD(CS%KPP_CSp, hbl, G, US, m_to_BLD_units=GV%m_to_H)
@@ -790,15 +791,19 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
     ! lFPpost must be false in the predictor step to avoid averaging into the diagnostics
     lFPpost = .false.
+    !$omp target update from(up, vp, h)
     call vertFPmix(up, vp, uold, vold, hbl, h, forces, dt_pred, lFPpost, CS%Cemp_NL,  &
                    G, GV, US, CS%vertvisc_CSp, CS%OBC, waves=waves)
+    !$omp target update to (up, vp)
+
     call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%AD_pred, CS%CDp, G, &
                   GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, fpmix=CS%fpmix, waves=waves)
   else
     call vertvisc(up, vp, h, forces, visc, dt_pred, CS%OBC, CS%AD_pred, CS%CDp, G, &
                   GV, US, CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
-
   endif
+  !$omp target update from(up, vp)
+  !$omp target update from(CS%taux_bot, CS%tauy_bot)
 
   if (showCallTree) call callTree_wayPoint("done with vertvisc (step_MOM_dyn_split_RK2)")
   if (G%nonblocking_updates) then
@@ -806,12 +811,13 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     call start_group_pass(CS%pass_uvp, G%Domain, clock=id_clock_pass)
     call cpu_clock_begin(id_clock_vertvisc)
   endif
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
   if (CS%visc_rem_dt_bug) then
     call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt_pred, G, GV, US, CS%vertvisc_CSp)
-
   else
     call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
   endif
+  !$omp target update from(CS%visc_rem_u, CS%visc_rem_v)
   call cpu_clock_end(id_clock_vertvisc)
 
   call do_group_pass(CS%pass_visc_rem, G%Domain, clock=id_clock_pass)
@@ -1074,26 +1080,31 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   !$omp target update to(u_inst, v_inst, h, dz)
   call vertvisc_coef(u_inst, v_inst, h, dz, forces, visc, tv, dt, G, GV, US, CS%vertvisc_CSp, CS%OBC, VarMix)
 
-
   if (CS%fpmix) then
     lFPpost = .true.
+    !$omp target update from(u_inst, v_inst, h)
     call vertFPmix(u_inst, v_inst, uold, vold, hbl, h, forces, dt, lFPpost, CS%Cemp_NL, &
                    G, GV, US, CS%vertvisc_CSp, CS%OBC, Waves=Waves)
+    !$omp target update to(u_inst, v_inst)
+
     call vertvisc(u_inst, v_inst, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
          CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, fpmix=CS%fpmix, waves=waves)
 
   else
     call vertvisc(u_inst, v_inst, h, forces, visc, dt, CS%OBC, CS%ADp, CS%CDp, G, GV, US, &
                   CS%vertvisc_CSp, CS%taux_bot, CS%tauy_bot, waves=waves)
-
   endif
+  !$omp target update from(u_inst, v_inst)
+  !$omp target update from(CS%taux_bot, CS%tauy_bot)
 
   if (G%nonblocking_updates) then
     call cpu_clock_end(id_clock_vertvisc)
     call start_group_pass(CS%pass_uv, G%Domain, clock=id_clock_pass)
     call cpu_clock_begin(id_clock_vertvisc)
   endif
-    call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
+  !$omp target update to(CS%visc_rem_u, CS%visc_rem_v)
+  call vertvisc_remnant(visc, CS%visc_rem_u, CS%visc_rem_v, dt, G, GV, US, CS%vertvisc_CSp)
+  !$omp target update from(CS%visc_rem_u, CS%visc_rem_v)
 
   call cpu_clock_end(id_clock_vertvisc)
   if (showCallTree) call callTree_wayPoint("done with vertvisc (step_MOM_dyn_split_RK2)")
@@ -1585,6 +1596,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
 
   allocate(CS%taux_bot(IsdB:IedB,jsd:jed), source=0.0)
   allocate(CS%tauy_bot(isd:ied,JsdB:JedB), source=0.0)
+  !$omp target enter data map(to: CS%taux_bot, CS%tauy_bot)
 
   ALLOC_(CS%uhbt(IsdB:IedB,jsd:jed))          ; CS%uhbt(:,:)         = 0.0
   ALLOC_(CS%vhbt(isd:ied,JsdB:JedB))          ; CS%vhbt(:,:)         = 0.0
@@ -1597,9 +1609,9 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
   !$omp target enter data map(alloc: CS%pbce, CS%eta_PF)
   ALLOC_(CS%u_accel_bt(IsdB:IedB,jsd:jed,nz)) ; CS%u_accel_bt(:,:,:) = 0.0
   ALLOC_(CS%v_accel_bt(isd:ied,JsdB:JedB,nz)) ; CS%v_accel_bt(:,:,:) = 0.0
+  !$omp target enter data map(alloc: CS%u_accel_bt, CS%v_accel_bt)
   ALLOC_(CS%PFu_Stokes(IsdB:IedB,jsd:jed,nz)) ; CS%PFu_Stokes(:,:,:) = 0.0
   ALLOC_(CS%PFv_Stokes(isd:ied,JsdB:JedB,nz)) ; CS%PFv_Stokes(:,:,:) = 0.0
-  !$omp target enter data map(alloc: CS%u_accel_bt, CS%v_accel_bt)
 
   MIS%diffu      => CS%diffu
   MIS%diffv      => CS%diffv

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -1445,6 +1445,8 @@ subroutine initialize_dyn_split_RK2b(u, v, h, tv, uh, vh, eta, Time, G, GV, US, 
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, CS%ADp, &
                           CS%SAL_CSp, CS%tides_CSp)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc, ADp=CS%ADp)
+
+  allocate(CS%vertvisc_CSp)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
                      ntrunc, CS%vertvisc_CSp)
   CS%set_visc_CSp => set_visc

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -716,6 +716,8 @@ subroutine initialize_dyn_unsplit(u, v, h, tv, Time, G, GV, US, param_file, diag
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, CS%ADp, &
                           CS%SAL_CSp, CS%tides_CSp)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc)
+
+  allocate(CS%vertvisc_CSp)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
                      ntrunc, CS%vertvisc_CSp)
   CS%set_visc_CSp => set_visc

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -679,6 +679,8 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, tv, Time, G, GV, US, param_file, 
   call PressureForce_init(Time, G, GV, US, param_file, diag, CS%PressureForce_CSp, CS%ADp, &
                           CS%SAL_CSp, CS%tides_CSp)
   call hor_visc_init(Time, G, GV, US, param_file, diag, CS%hor_visc)
+
+  allocate(CS%vertvisc_CSp)
   call vertvisc_init(MIS, Time, G, GV, US, param_file, diag, CS%ADp, dirs, &
                      ntrunc, CS%vertvisc_CSp)
   CS%set_visc_CSp => set_visc

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -2850,8 +2850,10 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
     endif
 
     ! Determine the thickness of the surface ocean boundary layer and its extent in index space.
-    nk_in_ml(:,:) = 0
-    !$omp target enter data map(to: nk_in_ml)
+    !$omp target enter data map(alloc: nk_in_ml)
+    do concurrent (j=js:je, i=is:ie, do_i(i,j))
+      nk_in_ml(i,j) = 0
+    enddo
 
     if (CS%dynamic_viscous_ML) then
       ! The fractional number of layers that are within the viscous boundary layer were
@@ -3024,6 +3026,7 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
 
   !$omp target exit data map(delete: u_star, absf, tau_mag)
   !$omp target exit data map(delete: z_t, Kv_tot, Kv_add)
+  !$omp target exit data map(delete: nk_in_ml)
   !$omp target exit data map(release: visc%Kv_shear)
 
 end subroutine find_coupling_coef

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -1452,7 +1452,6 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
   real, dimension(SZIB_(G),SZJB_(G)) :: &
     kv_bbl, &     ! The bottom boundary layer viscosity [H Z T-1 ~> m2 s-1 or Pa s].
     bbl_thick, &  ! The bottom boundary layer thickness [Z ~> m].
-    test_bbl_thick, &  ! The bottom boundary layer thickness [Z ~> m].
     I_Hbbl, &     ! The inverse of the bottom boundary layer thickness [Z-1 ~> m-1].
     I_Hbbl_gl90, &! The inverse of the bottom boundary layer thickness used for the GL90 scheme
                   ! [Z-1 ~> m-1].
@@ -1566,20 +1565,13 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
     do_i(I,j) = G%mask2dCu(I,j) > 0.
   enddo
 
-  if (CS%bottomdraglaw) then
-    do j=js,je ; do I=Isq,Ieq ; if (do_i(I,j)) then
-      test_bbl_thick(I,j) = visc%bbl_thick_u(I,j) + dz_neglect
-    endif ; enddo ; enddo
-  endif
-
   !$omp target enter data map(alloc: a_cpl, h_ml)
   !$omp target enter data map(alloc: kv_bbl, bbl_thick, I_Hbbl)
-  !$omp target enter data map(alloc: h_harm, h_arith, dz_harm, h_delta, dz_arith, hvel, dz_vel, z_i)
+  !$omp target enter data map(alloc: h_harm, h_arith, h_delta, hvel)
+  !$omp target enter data map(alloc: dz_harm, dz_arith, dz_vel)
   !$omp target enter data map(alloc: Dmin, zi_dir)
-  !$omp target enter data map(alloc: zh, zcol)
+  !$omp target enter data map(alloc: z_i, zh, zcol)
 
-  ! JORGE TODO: for some reason I need to map visc bbl thuck u like this herem instead of up there
-  ! I am doing this for the reast of the things later
   if (CS%bottomdraglaw) then
     do concurrent (j=js:je, I=Isq:Ieq, do_i(I,j))
       kv_bbl(I,j) = visc%Kv_bbl_u(I,j)
@@ -1765,41 +1757,41 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
   endif
 
   do_any_shelf = .false.
-  if (associated(forces%frac_shelf_u)) then !{
+  if (associated(forces%frac_shelf_u)) then
     do j=js,je ; do I=Isq,Ieq
       CS%a1_shelf_u(I,j) = 0.
       do_i_shelf(I,j) = do_i(I,j) .and. forces%frac_shelf_u(I,j) > 0.
     enddo ; enddo
     do_any_shelf = any(do_i_shelf)
 
-    if (do_any_shelf) then !{
-      if (.not. CS%harmonic_visc) then !{
+    if (do_any_shelf) then
+      if (.not. CS%harmonic_visc) then
         do j=js,je ; do I=Isq,Ieq ; if (do_i_shelf(I,j)) then
           zh(I,j) = 0.
           Ztop_min(I,j) = min(zcol(i,j), zcol(i+1,j))
           I_HTbl(I,j) = 1. / (visc%tbl_thick_shelf_u(I,j) + dz_neglect)
         endif ; enddo ; enddo
-      endif !}
+      endif
 
       do k=1,nz
-        if (CS%harmonic_visc) then !{
+        if (CS%harmonic_visc) then
           do j=js,je ; do I=Isq,Ieq
             hvel_shelf(I,j,k) = hvel(I,j,k)
             dz_vel_shelf(I,j,k) = dz_vel(I,j,k)
           enddo ; enddo
-        else !}{
+        else
           ! Find upwind-biased thickness near the surface.
           ! (Perhaps this needs to be done more carefully, via find_eta.)
-          do j=js,je ; do I=Isq,Ieq ; if (do_i(I,j)) then !{
+          do j=js,je ; do I=Isq,Ieq ; if (do_i(I,j)) then
             h_harm(I,j) = 2. * h(i,j,k) * h(i+1,j,k) &
                 / (h(i,j,k) + h(i+1,j,k) + h_neglect)
             h_arith(I,j) = 0.5 * (h(i+1,j,k) + h(i,j,k))
             h_delta(I,j) = h(i+1,j,k) - h(i,j,k)
             dz_arith(I,j) = 0.5 * (dz(i+1,j,k) + dz(i,j,k))
-          endif ; enddo ; enddo !}
+          endif ; enddo ; enddo
 
-          if (associated(OBC)) then !{
-            if (OBC%u_E_OBCs_on_PE) then !{
+          if (associated(OBC)) then
+            if (OBC%u_E_OBCs_on_PE) then
               do j=js_E_OBC,je_E_OBC ; do I=Is_E_OBC,Ie_E_OBC
                 if (do_i(I,j) .and. OBC%segnum_u(I,j) > 0) then
                   h_harm(I,j) = h(i,j,k)
@@ -1808,9 +1800,9 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
                   dz_arith(I,j) = dz(i,j,k)
                 endif
               enddo ; enddo
-            endif !}
+            endif
 
-            if (OBC%u_W_OBCs_on_PE) then !{
+            if (OBC%u_W_OBCs_on_PE) then
               do j=js_W_OBC,je_W_OBC ; do I=Is_W_OBC,Ie_W_OBC
                 if (do_i(I,j) .and. OBC%segnum_u(I,j) < 0) then
                   h_harm(I,j) = h(i+1,j,k)
@@ -1819,24 +1811,24 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
                   dz_arith(I,j) = dz(i+1,j,k)
                 endif
               enddo ; enddo
-            endif !}
-          endif !}
+            endif
+          endif
 
           do j=js,je ; do i=Isq,Ieq+1
             zcol(i,j) = zcol(i,j) - dz(i,j,k)
           enddo ; enddo
 
-          do j=js,je ; do I=Isq,Ieq ; if (do_i_shelf(I,j)) then !{
+          do j=js,je ; do I=Isq,Ieq ; if (do_i_shelf(I,j)) then
             zh(I,j) = zh(I,j) + dz_harm(I,j,k)
 
             hvel_shelf(I,j,k) = hvel(I,j,k)
             dz_vel_shelf(I,j,k) = dz_vel(I,j,k)
 
-            if (u(I,j,k) * h_delta(I,j) > 0) then !{
-              if (zh(I,j) * I_HTbl(I,j) < CS%harm_BL_val) then !{
+            if (u(I,j,k) * h_delta(I,j) > 0) then
+              if (zh(I,j) * I_HTbl(I,j) < CS%harm_BL_val) then
                 hvel_shelf(I,j,k) = min(hvel(I,j,k), h_harm(I,j))
                 dz_vel_shelf(I,j,k) = min(dz_vel(I,j,k), dz_harm(I,j,k))
-              else !}{
+              else
                 z2_wt = 1.
                 if (zh(I,j) * I_HTbl(I,j) < 2. * CS%harm_BL_val) &
                   z2_wt = max(0., min(1., zh(I,j) * I_HTbl(I,j) * I_valBL - 1.))
@@ -1849,10 +1841,10 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
 
                 hvel_shelf(I,j,k) = min(hvel(I,j,k), (1. - topfn) * h_arith(I,j) + topfn * h_harm(I,j))
                 dz_vel_shelf(I,j,k) = min(dz_vel(I,j,k), (1. - topfn) * dz_arith(I,j) + topfn * dz_harm(I,j,k))
-              endif !}
-            endif !}
-          endif ; enddo ; enddo !}
-        endif !}
+              endif
+            endif
+          endif ; enddo ; enddo
+        endif
       enddo
       call find_coupling_coef(a_shelf, dz_vel_shelf, do_i_shelf, dz_harm, &
           bbl_thick, kv_bbl, z_i, h_ml, dt, G, GV, US, CS, visc, Ustar_2d, &
@@ -1861,11 +1853,11 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
       do j=js,je ; do I=Isq,Ieq ; if (do_i_shelf(I,j)) then
         CS%a1_shelf_u(I,j) = a_shelf(I,j,1)
       endif ; enddo ; enddo
-    endif !}
-  endif !}
+    endif
+  endif
 
-  if (do_any_shelf) then !{
-    if (CS%use_GL90_in_SSW) then !{
+  if (do_any_shelf) then
+    if (CS%use_GL90_in_SSW) then
       do K=1,nz+1
         do j=js,je ; do I=Isq,Ieq
           if (do_i_shelf(I,j)) then
@@ -1882,7 +1874,7 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
           endif
         enddo ; enddo
       enddo
-    else !}{
+    else
       do K=1,nz+1
         do j=js,je ; do I=Isq,Ieq
           if (do_i_shelf(I,j)) then
@@ -1897,7 +1889,7 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
           endif
         enddo ; enddo
       enddo
-    endif !}
+    endif
 
     do k=1,nz
       do j=js,je ; do I=Isq,Ieq
@@ -1910,8 +1902,8 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
         endif
       enddo ; enddo
     enddo
-  else !}{
-    if (CS%use_GL90_in_SSW) then !{
+  else
+    if (CS%use_GL90_in_SSW) then
       do K=1,nz+1
         do j=js,je ; do I=Isq,Ieq ; if (do_i(I,j)) then
           a_cpl(I,j,K) = a_cpl(I,j,K) + a_cpl_gl90(I,j,K)
@@ -1923,7 +1915,7 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
           CS%a_u_gl90(I,j,K) = min(a_cpl_max, a_cpl_gl90(I,j,K))
         endif ; enddo ; enddo
       enddo
-    endif !}
+    endif
 
     do K=1,nz+1
       do concurrent (j=js:je, i=isq:ieq, do_i(i,j))
@@ -1936,7 +1928,7 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
         CS%h_u(I,j,k) = hvel(I,j,k) + h_neglect
       enddo
     enddo
-  endif !}
+  endif
 
   ! Diagnose total Kv at u-points
   if (CS%id_Kv_u > 0) then
@@ -3030,7 +3022,6 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
     endif
   endif
 
-  !check, nk_in_ml can probably be released, instead of frommed
   !$omp target exit data map(delete: u_star, absf, tau_mag)
   !$omp target exit data map(delete: z_t, Kv_tot, Kv_add)
   !$omp target exit data map(release: visc%Kv_shear)

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -690,7 +690,7 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
   endif
 
   !$omp target enter data map(to: ADp)
-  !$omp target update to(u, h,v)
+  !!$omp target update to(u, h,v)
   !$omp target enter data map(alloc: surface_stress)
   !$omp target enter data map(alloc: ADp%dv_dt_str)
   !$omp target enter data map(alloc: ADp%du_dt_str)
@@ -1178,14 +1178,14 @@ subroutine vertvisc(u, v, h, forces, visc, dt, OBC, ADp, CDp, G, GV, US, CS, &
 
   call vertvisc_limit_vel(u, v, h, ADp, CDp, forces, visc, dt, G, GV, US, CS)
 
-  !$omp target exit data map(delete: b1, c1, d1)
+  !$omp target exit data map(delete: b1, c1, d1, Ray)
 
-  !$omp target update from(u,v)
+  !!$omp target update from(u,v)
   !$omp target exit data map(from: ADp%du_dt_str, ADp%dv_dt_str)
-  !$omp target exit data map(from: surface_stress)
-  !$omp target exit data map(from: Ray)
   !$omp target exit data map(delete: ADp)
+  !$omp target exit data map(delete: surface_stress)
   !$omp target exit data map(delete: visc%Ray_u) if (allocated(visc%Ray_u))
+  !$omp target exit data map(delete: visc%Ray_v) if (allocated(visc%Ray_v))
 
   ! Here the velocities associated with open boundary conditions are applied.
   if (associated(OBC)) then
@@ -1303,7 +1303,6 @@ subroutine vertvisc_remnant(visc, visc_rem_u, visc_rem_v, dt, G, GV, US, CS)
          "Module must be initialized before it is used.")
 
   ! Find the zonal viscous remnant using a modification of a standard tridagonal solver.
-  !$omp target enter data map(to: visc_rem_u, visc_rem_v)
 
   !$omp target enter data map(alloc: b1, c1, d1, Ray, b_denom_1)
 
@@ -1386,10 +1385,10 @@ subroutine vertvisc_remnant(visc, visc_rem_u, visc_rem_v, dt, G, GV, US, CS)
       visc_rem_v(i,J,k) = visc_rem_v(i,J,k) + c1(i,J,k+1) * visc_rem_v(i,J,k+1)
     enddo
   enddo
+  !$omp target exit data map(delete: b1, c1, d1, Ray, b_denom_1)
 
-  !$omp target update from(visc_rem_u, visc_rem_v)
-  !$omp target exit data map(delete: b1, c1, d1, Ray,  b_denom_1)
   if (CS%debug) then
+    !$omp target update from(visc_rem_u, visc_rem_v)
     call uvchksum("visc_rem_[uv]", visc_rem_u, visc_rem_v, G%HI, haloshift=0, &
                   scalar_pair=.true.)
   endif
@@ -1555,15 +1554,17 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
   endif
 
   call find_ustar(forces, tv, Ustar_2d, G, GV, US, halo=1)
+  !$omp target enter data map(to: Ustar_2d)
 
   ! First do u-points
 
   ! Force IPO optimizations (e.g. Intel)
   ij = touch_ij(i,j)
 
-  do j=js,je ; do I=Isq,Ieq
+  !$omp target enter data map(alloc: do_i)
+  do concurrent (j=js:je, I=Isq:Ieq)
     do_i(I,j) = G%mask2dCu(I,j) > 0.
-  enddo ; enddo
+  enddo
 
   if (CS%bottomdraglaw) then
     do j=js,je ; do I=Isq,Ieq ; if (do_i(I,j)) then
@@ -1571,10 +1572,8 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
     endif ; enddo ; enddo
   endif
 
-  !$omp target enter data map(to: do_i)
-
   !$omp target enter data map(alloc: a_cpl, h_ml)
-  !$omp target enter data map(alloc: i_hbbl, bbl_thick, kv_bbl)
+  !$omp target enter data map(alloc: kv_bbl, bbl_thick, I_Hbbl)
   !$omp target enter data map(alloc: h_harm, h_arith, dz_harm, h_delta, dz_arith, hvel, dz_vel, z_i)
   !$omp target enter data map(alloc: Dmin, zi_dir)
   !$omp target enter data map(alloc: zh, zcol)
@@ -2325,12 +2324,13 @@ subroutine vertvisc_coef(u, v, h, dz, forces, visc, tv, dt, G, GV, US, CS, OBC, 
   endif
 
   !$omp target exit data map(release: a_cpl, h_ml)
-  !$omp target exit data map(from: do_i)
 
-  !$omp target exit data map(delete: bbl_thick, i_hbbl, kv_bbl)
+  !$omp target exit data map(delete: kv_bbl, bbl_thick, I_Hbbl)
   !$omp target exit data map(delete: h_harm, h_arith, dz_harm, h_delta, dz_arith, z_i, hvel, dz_vel)
   !$omp target exit data map(delete: zh, zcol)
   !$omp target exit data map(delete: Dmin, zi_dir)
+  !$omp target exit data map(delete: do_i)
+  !$omp target exit data map(delete: Ustar_2d)
 
   ! Diagnose total Kv at v-points
   if (CS%id_Kv_v > 0) then
@@ -2518,10 +2518,8 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
   enddo
 
   !$omp target enter data map(alloc: z_t, Kv_tot, Kv_add)
-  !$omp target enter data map(alloc: absf)
-  !$omp target enter data map(alloc: u_star, tau_mag)
+  !$omp target enter data map(alloc: u_star, absf, tau_mag)
   !$omp target enter data map(to: visc%Kv_shear)
-  !$omp target enter data map(to: Ustar_2d)
 
   if (CS%Kvml_invZ2 > 0. .and. .not. do_shelf) then
     I_Hmix = 1. / (CS%Hmix + h_neglect)
@@ -2859,7 +2857,6 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
       enddo
     endif
 
-
     ! Determine the thickness of the surface ocean boundary layer and its extent in index space.
     nk_in_ml(:,:) = 0
     !$omp target enter data map(to: nk_in_ml)
@@ -3034,15 +3031,9 @@ subroutine find_coupling_coef(a_cpl, hvel, do_i, h_harm, bbl_thick, kv_bbl, z_i,
   endif
 
   !check, nk_in_ml can probably be released, instead of frommed
-  !$omp target update from(bbl_thick, kv_bbl, Kv_add)
-  !$omp target update from(z_t, Kv_tot)
-  !$omp target exit data map(from: u_star, tau_mag)
-  !$omp target exit data map(from: absf, nk_in_ml)
-  !$omp target exit data map(delete: u_star, tau_mag)
-  !$omp target exit data map(delete: absf)
+  !$omp target exit data map(delete: u_star, absf, tau_mag)
   !$omp target exit data map(delete: z_t, Kv_tot, Kv_add)
   !$omp target exit data map(release: visc%Kv_shear)
-  !$omp target exit data map(release: Ustar_2d)
 
 end subroutine find_coupling_coef
 

--- a/src/parameterizations/vertical/MOM_vert_friction.F90
+++ b/src/parameterizations/vertical/MOM_vert_friction.F90
@@ -3331,15 +3331,6 @@ subroutine vertvisc_init(MIS, Time, G, GV, US, param_file, diag, ADp, dirs, &
   character(len=40)  :: thickness_units
   real :: Kv_mks ! KVML in MKS [m2 s-1]
 
-  ! TODO: Remove?
-#ifndef __NVCOMPILER_LLVM__
-    if (associated(CS)) then
-    call MOM_error(WARNING, "vertvisc_init called with an associated "// &
-                            "control structure.")
-    return
-  endif
-  allocate(CS)
-#endif
   CS%initialized = .true.
 
   if (GV%Boussinesq) then; thickness_units = "m"


### PR DESCRIPTION
Two commits to the vertvisc PR:

* The preprocessor directives for the vertvisc CS were removed.  An issue was resolved in the CI where the other timestep solvers (unsplit etc) were not allocating the CS.

* Some data transfers were cleanedup and reduced.